### PR TITLE
feat: Move Notifications tab to top navigation bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Auth from "./pages/Auth";
 import Chat from "./pages/Chat";
 import Users from "./pages/Users";
 import Profile from "./pages/Profile";
+import NotificationsPage from "./pages/Notifications";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -63,6 +64,11 @@ const App = () => (
           <Route path="/profile" element={
             <ProtectedRoute>
               <Profile />
+            </ProtectedRoute>
+          } />
+          <Route path="/notifications" element={
+            <ProtectedRoute>
+              <NotificationsPage />
             </ProtectedRoute>
           } />
           <Route path="*" element={<NotFound />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,7 +5,8 @@ import {
   MessageCircle, 
   Users, 
   Settings, 
-  LogOut 
+  LogOut,
+  Bell
 } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/hooks/use-toast';
@@ -39,6 +40,11 @@ const Navigation = () => {
       path: '/users',
       label: 'Users',
       icon: Users,
+    },
+    {
+      path: '/notifications',
+      label: 'Notifications',
+      icon: Bell,
     },
     {
       path: '/profile',

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,0 +1,22 @@
+import Notifications from '@/components/Notifications';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+const NotificationsPage = () => {
+  return (
+    <div className="container mx-auto p-4 max-w-2xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Notifications</CardTitle>
+          <CardDescription>
+            Manage your DM requests and other notifications
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Notifications />
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default NotificationsPage;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -6,8 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
-import { Camera, Save, Shield, Filter, Bell, Settings } from 'lucide-react';
-import Notifications from '@/components/Notifications';
+import { Camera, Save, Shield, Filter, Settings } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
@@ -36,7 +35,7 @@ const Profile = () => {
   const { toast } = useToast();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [uploading, setUploading] = useState(false);
-  const [activeTab, setActiveTab] = useState<'profile' | 'settings' | 'notifications'>('profile');
+  const [activeTab, setActiveTab] = useState<'profile' | 'settings'>('profile');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<ProfileData>({
@@ -230,15 +229,6 @@ const Profile = () => {
           <Shield className="h-4 w-4 mr-2" />
           Privacy & Safety
         </Button>
-        <Button
-          variant={activeTab === 'notifications' ? 'default' : 'ghost'}
-          size="sm"
-          onClick={() => setActiveTab('notifications')}
-          className="flex-1"
-        >
-          <Bell className="h-4 w-4 mr-2" />
-          Notifications
-        </Button>
       </div>
 
       {activeTab === 'profile' && (
@@ -361,20 +351,6 @@ const Profile = () => {
                 />
               </div>
             </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {activeTab === 'notifications' && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Notifications</CardTitle>
-            <CardDescription>
-              Manage your DM requests and other notifications
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Notifications />
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
Moves the "Notifications" tab from the settings menu to its own page, accessible from the top navigation bar. This improves visibility and accessibility of notifications.