### PR TITLE
feat: Move Notifications tab and embed Chat in Users page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import { useAuth } from "@/hooks/use-auth";
 import Navigation from "@/components/Navigation";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
-import Chat from "./pages/Chat";
 import Users from "./pages/Users";
 import Profile from "./pages/Profile";
 import NotificationsPage from "./pages/Notifications";
@@ -49,11 +48,6 @@ const App = () => (
           <Route path="/" element={
             <ProtectedRoute>
               <Index />
-            </ProtectedRoute>
-          } />
-          <Route path="/chat" element={
-            <ProtectedRoute>
-              <Chat />
             </ProtectedRoute>
           } />
           <Route path="/users" element={

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -28,13 +28,16 @@ interface Message {
   sender: User;
 }
 
-const Chat = () => {
-  const [searchParams] = useSearchParams();
+interface ChatWindowProps {
+  recipientId: string;
+  onBack: () => void;
+}
+
+const ChatWindow = ({ recipientId, onBack }: ChatWindowProps) => {
   const navigate = useNavigate();
   const { user: currentUser } = useAuth();
   const { toast } = useToast();
 
-  const recipientId = searchParams.get('recipient');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // State for the component
@@ -252,121 +255,101 @@ const Chat = () => {
     }
   };
 
-  // Placeholder for the UI when no user is selected
-  if (!recipientId) {
-    return (
-      <div className="container mx-auto p-4 max-w-4xl">
-        <Card className="h-[600px] flex flex-col items-center justify-center">
-          <CardContent className="text-center">
-            <MessageCircle className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
-            <h2 className="text-2xl font-semibold mb-2">Select a user to chat with</h2>
-            <p className="text-muted-foreground mb-6">
-              Choose someone from the users list to start a conversation.
-            </p>
-            <Button onClick={() => navigate('/users')}>Browse Users</Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
   return (
-    <div className="container mx-auto p-4 max-w-4xl">
-      <Card className="h-[600px] flex flex-col">
-        <CardHeader className="border-b border-border">
-          {recipient ? (
-            <CardTitle className="flex items-center space-x-3">
-              <Button variant="ghost" size="sm" onClick={() => navigate('/users')} className="mr-2">
-                <ArrowLeft className="h-4 w-4" />
-              </Button>
-              <Avatar className="h-8 w-8">
-                <AvatarImage src={recipient.avatar_url} />
-                <AvatarFallback>{recipient.name?.charAt(0).toUpperCase()}</AvatarFallback>
-              </Avatar>
-              <span>{recipient.name}</span>
-            </CardTitle>
-          ) : (
-            <div className="animate-pulse h-8 bg-muted rounded w-1/2"></div>
-          )}
-        </CardHeader>
+    <Card className="h-[600px] flex flex-col">
+      <CardHeader className="border-b border-border">
+        {recipient ? (
+          <CardTitle className="flex items-center space-x-3">
+            <Button variant="ghost" size="sm" onClick={onBack} className="mr-2">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <Avatar className="h-8 w-8">
+              <AvatarImage src={recipient.avatar_url} />
+              <AvatarFallback>{recipient.name?.charAt(0).toUpperCase()}</AvatarFallback>
+            </Avatar>
+            <span>{recipient.name}</span>
+          </CardTitle>
+        ) : (
+          <div className="animate-pulse h-8 bg-muted rounded w-1/2"></div>
+        )}
+      </CardHeader>
 
-        <CardContent className="flex-1 flex flex-col p-0">
-          <ScrollArea className="flex-1 p-4">
-            <div className="space-y-4">
-              {loading ? (
-                <div className="flex justify-center items-center h-full pt-10">
-                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                </div>
-              ) : messages.length === 0 ? (
-                <div className="flex justify-center items-center h-full pt-10">
-                  <p className="text-muted-foreground">No messages yet. Start the conversation!</p>
-                </div>
-              ) : (
-                messages.map((message) => {
-                  const isOwnMessage = message.sender_id === currentUser?.id;
-                  const senderName = isOwnMessage ? currentUser?.user_metadata.name : message.sender.name;
-                  const senderAvatar = isOwnMessage ? currentUser?.user_metadata.avatar_url : message.sender.avatar_url;
+      <CardContent className="flex-1 flex flex-col p-0">
+        <ScrollArea className="flex-1 p-4">
+          <div className="space-y-4">
+            {loading ? (
+              <div className="flex justify-center items-center h-full pt-10">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              </div>
+            ) : messages.length === 0 ? (
+              <div className="flex justify-center items-center h-full pt-10">
+                <p className="text-muted-foreground">No messages yet. Start the conversation!</p>
+              </div>
+            ) : (
+              messages.map((message) => {
+                const isOwnMessage = message.sender_id === currentUser?.id;
+                const senderName = isOwnMessage ? currentUser?.user_metadata.name : message.sender.name;
+                const senderAvatar = isOwnMessage ? currentUser?.user_metadata.avatar_url : message.sender.avatar_url;
 
-                  return (
+                return (
+                  <div
+                    key={message.id}
+                    className={`flex items-end gap-2 ${isOwnMessage ? 'justify-end' : 'justify-start'}`}
+                  >
+                    {!isOwnMessage && (
+                      <Avatar className="h-8 w-8">
+                        <AvatarImage src={senderAvatar} />
+                        <AvatarFallback>{senderName?.charAt(0).toUpperCase()}</AvatarFallback>
+                      </Avatar>
+                    )}
                     <div
-                      key={message.id}
-                      className={`flex items-end gap-2 ${isOwnMessage ? 'justify-end' : 'justify-start'}`}
+                      className={`max-w-[70%] rounded-lg p-3 ${
+                        isOwnMessage
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-muted'
+                      }`}
                     >
-                      {!isOwnMessage && (
-                        <Avatar className="h-8 w-8">
-                          <AvatarImage src={senderAvatar} />
-                          <AvatarFallback>{senderName?.charAt(0).toUpperCase()}</AvatarFallback>
-                        </Avatar>
-                      )}
-                      <div
-                        className={`max-w-[70%] rounded-lg p-3 ${
-                          isOwnMessage
-                            ? 'bg-primary text-primary-foreground'
-                            : 'bg-muted'
-                        }`}
-                      >
-                        <p className="break-words">{message.content}</p>
-                        <p className="text-xs opacity-70 mt-1 text-right">
-                          {formatDistanceToNow(new Date(message.created_at), { addSuffix: true })}
-                        </p>
-                      </div>
-                       {isOwnMessage && currentUser && (
-                        <Avatar className="h-8 w-8">
-                          <AvatarImage src={senderAvatar} />
-                          <AvatarFallback>{senderName?.charAt(0).toUpperCase()}</AvatarFallback>
-                        </Avatar>
-                      )}
+                      <p className="break-words">{message.content}</p>
+                      <p className="text-xs opacity-70 mt-1 text-right">
+                        {formatDistanceToNow(new Date(message.created_at), { addSuffix: true })}
+                      </p>
                     </div>
-                  );
-                })
-              )}
-              <div ref={messagesEndRef} />
-            </div>
-          </ScrollArea>
-
-          <div className="border-t border-border p-4">
-            <div className="flex items-center space-x-2">
-              <Input
-                value={newMessage}
-                onChange={(e) => setNewMessage(e.target.value)}
-                onKeyPress={handleKeyPress}
-                placeholder="Type a message..."
-                disabled={sending || !currentUser}
-                className="flex-1"
-              />
-              <Button onClick={handleSendMessage} disabled={sending || !newMessage.trim() || !currentUser} size="sm" aria-label="Send message">
-                {sending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Send className="h-4 w-4" />
-                )}
-              </Button>
-            </div>
+                     {isOwnMessage && currentUser && (
+                      <Avatar className="h-8 w-8">
+                        <AvatarImage src={senderAvatar} />
+                        <AvatarFallback>{senderName?.charAt(0).toUpperCase()}</AvatarFallback>
+                      </Avatar>
+                    )}
+                  </div>
+                );
+              })
+            )}
+            <div ref={messagesEndRef} />
           </div>
-        </CardContent>
-      </Card>
-    </div>
+        </ScrollArea>
+
+        <div className="border-t border-border p-4">
+          <div className="flex items-center space-x-2">
+            <Input
+              value={newMessage}
+              onChange={(e) => setNewMessage(e.target.value)}
+              onKeyPress={handleKeyPress}
+              placeholder="Type a message..."
+              disabled={sending || !currentUser}
+              className="flex-1"
+            />
+            <Button onClick={handleSendMessage} disabled={sending || !newMessage.trim() || !currentUser} size="sm" aria-label="Send message">
+              {sending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 };
 
-export default Chat;
+export default ChatWindow;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -32,11 +32,6 @@ const Navigation = () => {
 
   const navItems = [
     {
-      path: '/chat',
-      label: 'Chat',
-      icon: MessageCircle,
-    },
-    {
       path: '/users',
       label: 'Users',
       icon: Users,

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
+import ChatWindow from '@/components/ChatWindow';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -23,8 +23,8 @@ const Users = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(true);
   const [pendingRequests, setPendingRequests] = useState<Set<string>>(new Set());
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const { user: currentUser, loading: authLoading } = useAuth();
-  const navigate = useNavigate();
   const { toast } = useToast();
 
   useEffect(() => {
@@ -151,7 +151,7 @@ const Users = () => {
     }
     
     // Normal chat flow
-    navigate(`/chat?recipient=${userId}`);
+    setSelectedUserId(userId);
   };
 
   if (loading) {
@@ -162,6 +162,17 @@ const Users = () => {
             <div key={i} className="h-16 bg-muted rounded-lg"></div>
           ))}
         </div>
+      </div>
+    );
+  }
+
+  if (selectedUserId) {
+    return (
+      <div className="container mx-auto p-4 max-w-4xl">
+        <ChatWindow
+          recipientId={selectedUserId}
+          onBack={() => setSelectedUserId(null)}
+        />
       </div>
     );
   }


### PR DESCRIPTION
- Moves the "Notifications" tab from the settings menu to its own page, accessible from the top navigation bar. This improves visibility and accessibility of notifications.

- Removes the standalone "Chat" tab and embeds the chat functionality directly into the "Users" page. Clicking a user now opens a chat window within the same page, streamlining the user flow.