### PR TITLE
feat: Implement notification badge and browser notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
+import { NotificationsProvider } from "./context/NotificationsContext";
 import Navigation from "@/components/Navigation";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
@@ -30,10 +31,12 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <Navigation />
-      <main>{children}</main>
-    </div>
+    <NotificationsProvider>
+      <div className="min-h-screen bg-background">
+        <Navigation />
+        <main>{children}</main>
+      </div>
+    </NotificationsProvider>
   );
 };
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,12 +10,14 @@ import {
 } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/hooks/use-toast';
+import { useNotifications } from '@/context/NotificationsContext';
 
 const Navigation = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, signOut } = useAuth();
   const { toast } = useToast();
+  const { count } = useNotifications();
 
   const handleSignOut = async () => {
     const { error } = await signOut();
@@ -65,10 +67,15 @@ const Navigation = () => {
                   <Button
                     variant={location.pathname === item.path ? 'default' : 'ghost'}
                     size="sm"
-                    className="flex items-center space-x-2"
+                    className="flex items-center space-x-2 relative"
                   >
                     <Icon className="h-4 w-4" />
                     <span>{item.label}</span>
+                    {item.label === 'Notifications' && count > 0 && (
+                      <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+                        {count}
+                      </span>
+                    )}
                   </Button>
                 </Link>
               );
@@ -108,10 +115,14 @@ const Navigation = () => {
                   <Button
                     variant={location.pathname === item.path ? 'default' : 'ghost'}
                     size="sm"
-                    className="flex flex-col items-center space-y-1"
+                    className="flex flex-col items-center space-y-1 relative"
                   >
                     <Icon className="h-4 w-4" />
                     <span className="text-xs">{item.label}</span>
+                    {item.label === 'Notifications' && count > 0 && (
+                      <span className="absolute top-0 right-0 flex h-3 w-3 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+                      </span>
+                    )}
                   </Button>
                 </Link>
               );

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -1,134 +1,11 @@
-import { useEffect, useState } from 'react';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/hooks/use-auth';
-import { useToast } from '@/hooks/use-toast';
+import { useNotifications } from '@/context/NotificationsContext';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Check, X, Bell } from 'lucide-react';
 
-interface DmRequest {
-  id: string;
-  sender_id: string;
-  recipient_id: string;
-  status: 'pending' | 'accepted' | 'rejected';
-  created_at: string;
-  sender?: {
-    name: string;
-    avatar_url?: string;
-  };
-}
-
 const Notifications = () => {
-  const { user } = useAuth();
-  const { toast } = useToast();
-  const [requests, setRequests] = useState<DmRequest[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (user) {
-      fetchPendingRequests();
-      setupRealtime();
-    }
-  }, [user]);
-
-  const fetchPendingRequests = async () => {
-    if (!user) return;
-
-    try {
-      const { data: dmRequests, error } = await supabase
-        .from('dm_requests')
-        .select('*')
-        .eq('recipient_id', user.id)
-        .eq('status', 'pending')
-        .order('created_at', { ascending: false });
-
-      if (error) throw error;
-
-      // Get sender info for each request
-      const requestsWithSenders = await Promise.all(
-        (dmRequests || []).map(async (request) => {
-          const { data: sender } = await supabase
-            .from('users')
-            .select('name, avatar_url')
-            .eq('id', request.sender_id)
-            .single();
-          
-          return {
-            ...request,
-            sender
-          };
-        })
-      );
-
-      setRequests(requestsWithSenders);
-    } catch (error) {
-      console.error('Error fetching DM requests:', error);
-      toast({
-        title: 'Error',
-        description: 'Failed to load notifications',
-        variant: 'destructive',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const setupRealtime = () => {
-    if (!user) return;
-
-    const channel = supabase
-      .channel('dm_requests')
-      .on(
-        'postgres_changes',
-        {
-          event: 'INSERT',
-          schema: 'public',
-          table: 'dm_requests',
-          filter: `recipient_id=eq.${user.id}`
-        },
-        (payload) => {
-          fetchPendingRequests(); // Refetch to get sender info
-        }
-      )
-      .subscribe();
-
-    return () => {
-      supabase.removeChannel(channel);
-    };
-  };
-
-  const handleRequestResponse = async (requestId: string, status: 'accepted' | 'rejected') => {
-    try {
-      const { data, error } = await supabase.functions.invoke('dm-request', {
-        body: {
-          action: 'respond',
-          request_id: requestId,
-          status
-        }
-      });
-
-      if (error) {
-        console.error('DM request response error:', error);
-        throw error;
-      }
-
-      // Remove from pending requests
-      setRequests(prev => prev.filter(req => req.id !== requestId));
-
-      toast({
-        title: 'Success',
-        description: status === 'accepted' ? 'DM request accepted' : 'DM request rejected',
-      });
-    } catch (error: any) {
-      console.error('Error responding to DM request:', error);
-      toast({
-        title: 'Error',
-        description: error.message || 'Failed to respond to request',
-        variant: 'destructive',
-      });
-    }
-  };
+  const { requests, loading, respondToRequest } = useNotifications();
 
   if (loading) {
     return (
@@ -174,13 +51,13 @@ const Notifications = () => {
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => handleRequestResponse(request.id, 'rejected')}
+                  onClick={() => respondToRequest(request.id, 'rejected')}
                 >
                   <X className="h-4 w-4" />
                 </Button>
                 <Button
                   size="sm"
-                  onClick={() => handleRequestResponse(request.id, 'accepted')}
+                  onClick={() => respondToRequest(request.id, 'accepted')}
                 >
                   <Check className="h-4 w-4" />
                 </Button>

--- a/src/context/NotificationsContext.tsx
+++ b/src/context/NotificationsContext.tsx
@@ -1,0 +1,156 @@
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/hooks/use-auth';
+import { useToast } from '@/hooks/use-toast';
+
+interface DmRequest {
+  id: string;
+  sender_id: string;
+  recipient_id: string;
+  status: 'pending' | 'accepted' | 'rejected';
+  created_at: string;
+  sender?: {
+    name: string;
+    avatar_url?: string;
+  };
+}
+
+interface NotificationsContextType {
+  requests: DmRequest[];
+  count: number;
+  loading: boolean;
+  respondToRequest: (requestId: string, status: 'accepted' | 'rejected') => Promise<void>;
+}
+
+const NotificationsContext = createContext<NotificationsContextType | undefined>(undefined);
+
+export const NotificationsProvider = ({ children }: { children: React.ReactNode }) => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [requests, setRequests] = useState<DmRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchPendingRequests = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      setLoading(true);
+      const { data: dmRequests, error } = await supabase
+        .from('dm_requests')
+        .select('*, sender:sender_id(name, avatar_url)')
+        .eq('recipient_id', user.id)
+        .eq('status', 'pending')
+        .order('created_at', { ascending: false });
+
+      if (error) throw error;
+      setRequests(dmRequests || []);
+    } catch (error) {
+      console.error('Error fetching DM requests:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to load notifications',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [user, toast]);
+
+  useEffect(() => {
+    if (user) {
+      fetchPendingRequests();
+    }
+  }, [user, fetchPendingRequests]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const channel = supabase
+      .channel('dm_requests_realtime')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'dm_requests',
+          filter: `recipient_id=eq.${user.id}`,
+        },
+        (payload) => {
+          if (payload.eventType === 'INSERT') {
+            const newRequest = payload.new as DmRequest;
+
+            // Fetch sender info for the notification content
+            supabase
+              .from('users')
+              .select('name, avatar_url')
+              .eq('id', newRequest.sender_id)
+              .single()
+              .then(({ data: sender }) => {
+                if (sender && Notification.permission === 'granted') {
+                  new Notification('New DM Request', {
+                    body: `${sender.name} wants to send you a message.`,
+                    icon: sender.avatar_url,
+                  });
+                }
+                fetchPendingRequests();
+              });
+          } else {
+            fetchPendingRequests();
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [user, fetchPendingRequests]);
+
+  const respondToRequest = async (requestId: string, status: 'accepted' | 'rejected') => {
+    try {
+      const { error } = await supabase.functions.invoke('dm-request', {
+        body: {
+          action: 'respond',
+          request_id: requestId,
+          status,
+        },
+      });
+
+      if (error) throw error;
+
+      setRequests((prev) => prev.filter((req) => req.id !== requestId));
+      toast({
+        title: 'Success',
+        description: `DM request ${status}`,
+      });
+    } catch (error: any) {
+      console.error('Error responding to DM request:', error);
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to respond to request',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const value = {
+    requests,
+    count: requests.length,
+    loading,
+    respondToRequest,
+  };
+
+  return (
+    <NotificationsContext.Provider value={value}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+export const useNotifications = () => {
+  const context = useContext(NotificationsContext);
+  if (context === undefined) {
+    throw new Error('useNotifications must be used within a NotificationsProvider');
+  }
+  return context;
+};

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,20 +1,10 @@
 import Notifications from '@/components/Notifications';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
 const NotificationsPage = () => {
   return (
     <div className="container mx-auto p-4 max-w-2xl">
-      <Card>
-        <CardHeader>
-          <CardTitle>Notifications</CardTitle>
-          <CardDescription>
-            Manage your DM requests and other notifications
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Notifications />
-        </CardContent>
-      </Card>
+      <h1 className="text-2xl font-bold mb-4">Notifications</h1>
+      <Notifications />
     </div>
   );
 };

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -36,6 +36,7 @@ const Profile = () => {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [uploading, setUploading] = useState(false);
   const [activeTab, setActiveTab] = useState<'profile' | 'settings'>('profile');
+  const [notificationPermission, setNotificationPermission] = useState(Notification.permission);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<ProfileData>({
@@ -71,6 +72,41 @@ const Profile = () => {
         title: 'Error',
         description: 'Failed to load profile',
         variant: 'destructive',
+      });
+    }
+  };
+
+  const handleNotificationPermission = async () => {
+    if (Notification.permission === 'granted') {
+      toast({
+        title: 'Permissions',
+        description: 'Browser notifications are already enabled.',
+      });
+      return;
+    }
+
+    if (Notification.permission === 'denied') {
+      toast({
+        title: 'Permissions Denied',
+        description: 'You have previously denied notification permissions. Please enable them in your browser settings.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    const permission = await Notification.requestPermission();
+    setNotificationPermission(permission);
+
+    if (permission === 'granted') {
+      toast({
+        title: 'Success',
+        description: 'Browser notifications have been enabled.',
+      });
+    } else {
+      toast({
+        title: 'Permissions',
+        description: 'You have not enabled browser notifications.',
+        variant: 'destructive'
       });
     }
   };
@@ -349,6 +385,22 @@ const Profile = () => {
                   checked={profile.privacy_mode}
                   onCheckedChange={(checked) => updateSetting('privacy_mode', checked)}
                 />
+              </div>
+              <Separator />
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label className="text-base">Browser Notifications</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Enable browser notifications for new DM requests.
+                  </p>
+                </div>
+                <Button
+                  onClick={handleNotificationPermission}
+                  disabled={notificationPermission === 'granted'}
+                  size="sm"
+                >
+                  {notificationPermission === 'granted' ? 'Enabled' : 'Enable'}
+                </Button>
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
This commit introduces a notification badge and browser push notifications for new DM requests.

- A `NotificationsProvider` context is created to manage notification state globally.
- The navigation bar now displays a badge with the count of unread notifications.
- Users can enable browser notifications from their profile settings.
- The `NotificationsProvider` triggers a push notification when a new DM request is received via the realtime subscription.

This enhances user experience by providing immediate and clear feedback on new notifications.