### PR TITLE
fix: Change profanity filter to be disabled by default

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -80,7 +80,7 @@ const Index = () => {
           <div className="bg-card p-4 rounded-lg border border-border">
             <h3 className="font-medium mb-2 text-card-foreground">Message Filtering</h3>
             <p className="text-sm text-muted-foreground">
-              All messages are automatically scanned and inappropriate content is filtered out.
+              Inappropriate content can be filtered from messages. This can be toggled in your profile settings.
             </p>
           </div>
           <div className="bg-card p-4 rounded-lg border border-border">

--- a/supabase/migrations/20250818175502_f3e8c157-4523-4b3c-8323-186c1dee9776.sql
+++ b/supabase/migrations/20250818175502_f3e8c157-4523-4b3c-8323-186c1dee9776.sql
@@ -1,6 +1,6 @@
 -- Add new fields to users table
 ALTER TABLE public.users 
-ADD COLUMN profanity_filter_enabled BOOLEAN DEFAULT true,
+ADD COLUMN profanity_filter_enabled BOOLEAN DEFAULT false,
 ADD COLUMN privacy_mode BOOLEAN DEFAULT false;
 
 -- Create enum for DM request status


### PR DESCRIPTION
- Updates the default value for `profanity_filter_enabled` in the database schema to `false`.
- Updates the description of the message filtering feature on the homepage to clarify that it's a user-controlled setting.