### PR TITLE
feat: Implement profanity filter and update homepage

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -226,14 +226,15 @@ const ChatWindow = ({ recipientId, onBack }: ChatWindowProps) => {
     setNewMessage('');
 
     try {
-      const { error } = await supabase
-        .from('messages')
-        .insert({
-          sender_id: currentUser.id,
-          recipient_id: recipientId,
-          content: messageContent,
-          media_type: 'text',
-        });
+      const { error } = await supabase.functions.invoke('sanitize-message', {
+        body: {
+          message: {
+            sender_id: currentUser.id,
+            recipient_id: recipientId,
+            content: messageContent,
+          },
+        },
+      });
 
       if (error) {
         console.error('Message send error:', error);

--- a/supabase/functions/sanitize-message/index.ts
+++ b/supabase/functions/sanitize-message/index.ts
@@ -8,6 +8,7 @@ const corsHeaders = {
 
 const profanityFilter = [
   'damn', 'hell', 'stupid', 'dumb', 'idiot', 'hate', 'kill', 'die',
+  'crap', 'poop', 'butt', 'heck'
   // Add more words as needed for school environment
 ];
 


### PR DESCRIPTION
- The client now invokes the `sanitize-message` edge function to filter messages for profanity, rather than inserting them directly into the database.
- The default value for the profanity filter is now set to `false` for new users.
- The homepage text has been updated to reflect that the profanity filter is a toggleable setting.
- The word list for the profanity filter has been enhanced.