### PR TITLE
fix(functions): Apply profanity filter based on recipient's setting

### DIFF
--- a/supabase/functions/sanitize-message/index.ts
+++ b/supabase/functions/sanitize-message/index.ts
@@ -28,11 +28,11 @@ serve(async (req) => {
 
     console.log('Processing message:', { sender_id, recipient_id, content: content ? 'has content' : 'no content', media_type });
 
-    // Check if sender has profanity filter enabled
+    // Check if recipient has profanity filter enabled
     const { data: userData, error: userError } = await supabase
       .from('users')
       .select('profanity_filter_enabled')
-      .eq('id', sender_id)
+      .eq('id', recipient_id)
       .single();
 
     if (userError) {


### PR DESCRIPTION
The `sanitize-message` edge function was previously checking the sender's `profanity_filter_enabled` setting. This has been corrected to check the recipient's setting.

This ensures that the filter is applied to a user's incoming messages, as per their own preference.