### PR TITLE
feat: Add card styling to empty notifications view

### DIFF
--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -90,10 +90,14 @@ const Notifications = () => {
 
   if (notifications.length === 0) {
     return (
-      <div className="text-center py-8">
-        <Bell className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-        <p className="text-muted-foreground">No pending notifications</p>
-      </div>
+      <Card>
+        <CardContent className="py-8">
+          <div className="text-center">
+            <Bell className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <p className="text-muted-foreground">No pending notifications</p>
+          </div>
+        </CardContent>
+      </Card>
     );
   }
 


### PR DESCRIPTION
Wraps the 'No pending notifications' message in a `Card` component to provide consistent styling with other notification elements. This adds a border and background to the message, improving the visual appearance of the empty state.