### PR TITLE
fix: Refresh auth session on avatar change

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -186,6 +186,13 @@ const Profile = () => {
 
       if (updateError) throw updateError;
 
+      // Also update the user metadata in the auth session
+      const { error: authUpdateError } = await supabase.auth.updateUser({
+        data: { avatar_url: publicUrl },
+      });
+
+      if (authUpdateError) throw authUpdateError;
+
       setProfile({ ...profile, avatar_url: publicUrl });
       toast({
         title: 'Success',


### PR DESCRIPTION
After a user uploads a new avatar, the public `users` table was being updated, but the Supabase Auth user metadata was not. This caused the navigation bar, which uses the auth metadata, to display the old avatar.

This change adds a call to `supabase.auth.updateUser()` after a successful avatar upload. This updates the user's metadata in the auth session, which triggers the `onAuthStateChange` listener in `useAuth`, ensuring the user object is refreshed and the new avatar is displayed correctly across the application.