### PR TITLE
fix: Hide unverified users from user list

### DIFF
--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -58,7 +58,8 @@ const Users = () => {
       const { data, error } = await supabase
         .from('users')
         .select('id, name, avatar_url, privacy_mode')
-        .neq('id', currentUser.id); // Exclude current user
+        .neq('id', currentUser.id) // Exclude current user
+        .not('email_confirmed_at', 'is', null); // Exclude unverified users
 
       if (error) throw error;
       setUsers(data || []);

--- a/supabase/migrations/20250821220926_add_email_confirmed_at_to_users.sql
+++ b/supabase/migrations/20250821220926_add_email_confirmed_at_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.users ADD COLUMN email_confirmed_at timestamptz;

--- a/supabase/migrations/20250821221028_add_update_trigger_for_user_verification.sql
+++ b/supabase/migrations/20250821221028_add_update_trigger_for_user_verification.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION public.handle_user_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE public.users
+  SET email_confirmed_at = NEW.email_confirmed_at
+  WHERE id = NEW.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE TRIGGER on_auth_user_updated
+  AFTER UPDATE ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_user_update();

--- a/supabase/migrations/20250821221101_update_handle_new_user_function.sql
+++ b/supabase/migrations/20250821221101_update_handle_new_user_function.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.users (id, name, email, email_confirmed_at)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'name', ''),
+    NEW.email,
+    NEW.email_confirmed_at
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
Unverified user accounts were previously visible to all other users in the application. This could lead to confusion and attempts to interact with accounts that had not yet completed the sign-up process.

This commit addresses the issue by:
1. Adding an `email_confirmed_at` column to the `public.users` table to track verification status.
2. Creating a new database migration to add a trigger (`on_auth_user_updated`) that updates the `email_confirmed_at` field in `public.users` when a user confirms their email in `auth.users`.
3. Creating a new database migration to update the `handle_new_user` function to populate the `email_confirmed_at` field (initially as null) when a new user is created.
4. Modifying the frontend query in `Users.tsx` to only fetch users where `email_confirmed_at` is not null.