### PR TITLE
fix: Correct database permissions to resolve user list error

### DIFF
--- a/supabase/migrations/20250821221825_update_user_select_privileges.sql
+++ b/supabase/migrations/20250821221825_update_user_select_privileges.sql
@@ -1,0 +1,3 @@
+-- Grant select access to the new email_confirmed_at column to the authenticated role.
+-- This allows the frontend to filter by this column without exposing any other data.
+GRANT SELECT (email_confirmed_at) ON TABLE public.users TO authenticated;


### PR DESCRIPTION
The previous commit introduced a regression where the user list would fail to load for all users. This was caused by an overly restrictive database migration that revoked all SELECT privileges from the `authenticated` role on the `public.users` table before granting column-specific ones. This broke existing Row Level Security policies that relied on those broader permissions.

This commit corrects the issue by:
1.  Modifying the migration to only `GRANT SELECT` on the new `email_confirmed_at` column, leaving existing privileges intact.
2.  Reverting the change to the `Users.tsx` component that explicitly listed all columns in the `select()` statement, as this is no longer necessary with the corrected permissions.