### PR TITLE
fix: Explicitly select columns in user query to fix loading error

### DIFF
--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -54,10 +54,12 @@ const Users = () => {
 
     try {
       // Only fetch basic user info (name, avatar_url) for discovery
-      // Email is now protected by RLS policies
+      // Email is now protected by RLS policies.
+      // We must explicitly select all columns we need, including ones for filtering,
+      // due to Column Level Security.
       const { data, error } = await supabase
         .from('users')
-        .select('id, name, avatar_url, privacy_mode')
+        .select('id, name, avatar_url, privacy_mode, email_confirmed_at')
         .neq('id', currentUser.id) // Exclude current user
         .not('email_confirmed_at', 'is', null); // Exclude unverified users
 


### PR DESCRIPTION
This commit is a further attempt to resolve the "Failed to load users" regression. The previous fix, which granted column-level SELECT permission on `email_confirmed_at`, was not sufficient.

This change makes the `select()` statement in the `fetchUsers` function more explicit by including `email_confirmed_at`. The hypothesis is that when Column Level Security is active on a table, the Supabase client requires all columns used in a query (including for `WHERE` clause filters) to be explicitly listed in the `select()` call.